### PR TITLE
Move /test directory under /nix

### DIFF
--- a/nix/test/flake.lock
+++ b/nix/test/flake.lock
@@ -79,11 +79,11 @@
     },
     "skills": {
       "locked": {
-        "path": "..",
+        "path": "../..",
         "type": "path"
       },
       "original": {
-        "path": "..",
+        "path": "../..",
         "type": "path"
       },
       "parent": []

--- a/nix/test/flake.nix
+++ b/nix/test/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
-    skills.url = "path:..";
+    skills.url = "path:../..";
   };
 
   outputs = inputs:

--- a/vira.hs
+++ b/vira.hs
@@ -2,7 +2,7 @@
 \ctx pipeline ->
   pipeline
     { signoff.enable = True
-    , build.flakes = [".", "./test" { overrideInputs = [("skills", ".")] }]
+    , build.flakes = [".", "./nix/test" { overrideInputs = [("skills", ".")] }]
     , build.systems = ["x86_64-linux", "aarch64-darwin"]
     , cache.url = Nothing  -- TODO: configure Attic cache URL
     }


### PR DESCRIPTION
## Summary

- Move `/test` to `/nix/test` to keep top-level clean
- Update `skills.url` path from `..` to `../..`
- Update vira.hs build config to reference new location

Closes #7