### PR TITLE
Add general Haskell skill with conditional relude guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 | Skill | Description |
 |-------|-------------|
 | [`cargo-watch`](./skills/cargo-watch/SKILL.md) | Run cargo-watch in the background for continuous clippy feedback during code editing |
+| [`haskell`](./skills/haskell/SKILL.md) | Haskell development — error handling, type safety, idiomatic patterns, HLint, Aeson, conditional relude guidance |
 | [`nix-ci`](./skills/nix-ci/SKILL.md) | CI setup for GitHub repos — GitHub Actions or Vira |
 | [`nix-flake`](./skills/nix-flake/SKILL.md) | Writing flakes with flake-parts, formatter, shell scripts, and language templates |
 | [`nix-haskell`](./skills/nix-haskell/SKILL.md) | Haskell projects with haskell-flake: dependencies, settings, devShell, autoWire |

--- a/skills/haskell/RELUDE.md
+++ b/skills/haskell/RELUDE.md
@@ -1,0 +1,77 @@
+# Relude Best Practices
+
+When using relude, follow these idiomatic substitutions (from [relude's HLint rules](https://github.com/kowainik/relude/blob/main/.hlint.yaml)):
+
+## Basic Idioms
+
+- `pass` instead of `pure ()` or `return ()`
+- `one` instead of `(: [])`, `(:| [])`, or singleton functions
+- `<<$>>` for double fmap: `f <<$>> x` instead of `fmap (fmap f) x`
+- `??` (flap) operator: `ff ?? x` instead of `fmap ($ x) ff`
+
+## File I/O
+
+- `readFileText`, `writeFileText`, `appendFileText` for Text
+- `readFileLText`, `writeFileLText`, `appendFileLText` for lazy Text
+- `readFileBS`, `writeFileBS`, `appendFileBS` for ByteString
+- `readFileLBS`, `writeFileLBS`, `appendFileLBS` for lazy ByteString
+
+## Console Output
+
+- `putText`, `putTextLn` for Text
+- `putLText`, `putLTextLn` for lazy Text
+- `putBS`, `putBSLn` for ByteString
+- `putLBS`, `putLBSLn` for lazy ByteString
+
+## Maybe/Either Helpers
+
+- `whenJust m f` instead of `maybe pass f m`
+- `whenJustM m f` for monadic versions
+- `whenNothing_ m x` / `whenNothingM_ m x` for Nothing cases
+- `whenLeft_ m f`, `whenRight_ m f` for Either
+- `whenLeftM_ m f`, `whenRightM_ m f` for monadic Either
+- `leftToMaybe`, `rightToMaybe` for conversions
+- `maybeToRight l`, `maybeToLeft r` for conversions
+
+## List Operations
+
+- `ordNub` instead of `nub` (O(n log n) vs O(n²))
+- `sortNub` instead of `Data.Set.toList . Data.Set.fromList`
+- `sortWith f` instead of `sortBy (comparing f)`
+- `viaNonEmpty f x` instead of `fmap f (nonEmpty x)`
+- `asumMap f xs` instead of `asum (map f xs)`
+- `toList` instead of `foldr (:) []`
+
+## Monadic Operations
+
+- `andM s` instead of `and <$> sequence s`
+- `orM s` instead of `or <$> sequence s`
+- `allM f s` instead of `and <$> mapM f s`
+- `anyM f s` instead of `or <$> mapM f s`
+- `guardM f` instead of `f >>= guard`
+- `infinitely` instead of `forever`
+- `unlessM (not <$> x)` → use `whenM x`
+- `whenM (not <$> x)` → use `unlessM x`
+
+## State/Reader Operations
+
+- `usingReaderT` instead of `flip runReaderT`
+- `usingStateT` instead of `flip runStateT`
+- `evaluatingStateT s st` instead of `fst <$> usingStateT s st`
+- `executingStateT s st` instead of `snd <$> usingStateT s st`
+
+## Transformer Lifting
+
+- `hoistMaybe m` instead of `MaybeT (pure m)`
+- `hoistEither m` instead of `ExceptT (pure m)`
+
+## List Pattern Matching
+
+- `whenNotNull m f` for `case m of [] -> pass; (x:xs) -> f (x :| xs)`
+- `whenNotNullM m f` for monadic version
+
+## Text/ByteString Conversions
+
+- `toText`, `toString`, `toLText` instead of pack/unpack
+- `encodeUtf8`, `decodeUtf8` for UTF-8 encoding
+- `fromStrict`, `toStrict` for lazy/strict conversions

--- a/skills/haskell/SKILL.md
+++ b/skills/haskell/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: haskell
+description: Use this when writing or reviewing Haskell code. Covers error handling, type safety, idiomatic patterns, HLint compliance, Aeson usage, and testing.
+---
+
+# Haskell Development
+
+## Error Handling
+
+- NEVER use `undefined` or `error` as placeholders
+- Handle ALL `Maybe`/`Either` cases explicitly — no silent ignoring
+- Handle all pattern match cases — no partial matches
+- Use types to make impossible states unrepresentable
+
+## Type Safety & Idioms
+
+- Write type signatures for all top-level definitions
+- Prefer `Text` over `String`
+- Use `newtype` wrappers for domain types
+- Apply smart constructors for validation
+- Write total functions — avoid `head`, `tail`, and other partial functions
+- Prefer pure functions over IO
+- Use explicit module exports
+- Favor composition over complex functions
+- Write Haddock documentation for public APIs
+
+## Records
+
+- Use `OverloadedRecordDot` (add pragma to modules that use the syntax)
+- Use `DisambiguateRecordFields` and `DuplicateRecordFields` for simple field names
+- Use lenses for record manipulation when appropriate
+
+## Aeson
+
+- NEVER construct aeson objects by hand
+- Create a type and use `encode`/`decode` on it
+- Prefer generic deriving; hand-write instances only when the wire format requires it
+
+## HLint
+
+If `.hlint.yaml` exists in the project root, run `hlint` on every modified file. Fix ALL warnings before considering the task complete.
+
+## Build Workflow
+
+If `ghcid.txt` exists in the project, check it after every code change for compile errors. Do not proceed until it is clean. If this file does not exist, use whatever build workflow the project documents.
+
+When adding or deleting `.hs` modules: update the `.cabal` file, or run `hpack` if `package.yaml` exists.
+
+## Relude
+
+If the project uses [relude](https://github.com/kowainik/relude) (check `.cabal` or `package.yaml` dependencies), also follow [RELUDE.md](RELUDE.md) for idiomatic substitutions.
+
+## Testing
+
+- QuickCheck for property-based testing
+- HUnit or Hspec for unit tests


### PR DESCRIPTION
**General-purpose Haskell skill** covering error handling, type safety, idiomatic patterns, and code quality — the language-level guidance that complements the existing `nix-haskell` build skill.

The skill is split into two files: `SKILL.md` for universal Haskell best practices (total functions, `Text` over `String`, newtype wrappers, Aeson via generic deriving, HLint compliance), and a companion `RELUDE.md` that the agent loads *only when the project actually uses relude*. This keeps the base skill prelude-agnostic while giving relude-heavy projects the idiomatic substitutions they need (`pass`, `ordNub`, `whenJust`, typed IO helpers, etc.).

> Build workflow guidance (ghcid) is kept conditional — "if `ghcid.txt` exists, check it" — rather than mandating a specific toolchain.

Closes #27