### PR TITLE
Add nix-playwright skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 | [`nix-haskell`](./skills/nix-haskell/SKILL.md) | Haskell projects with haskell-flake: dependencies, settings, devShell, autoWire |
 | [`nix-health`](./skills/nix-health/SKILL.md) | Diagnosing Nix installation health — flakes, version, caches, max-jobs, direnv, and shell config |
 | [`nix-justfile`](./skills/nix-justfile/SKILL.md) | Conventions for writing justfile recipes in Nix-based projects |
+| [`nix-playwright`](./skills/nix-playwright/SKILL.md) | Run an existing Playwright e2e suite locally on NixOS via `tests/shell.nix` + justfile |
 | [`nix-rust-leptos`](./skills/nix-rust-leptos/SKILL.md) | Conventions for building Leptos CSR apps with Nix (crane + Trunk) |
 | [`nix-typescript`](./skills/nix-typescript/SKILL.md) | pnpm + Nix build conventions — fetchPnpmDeps hash management and dependency workflow |
 | [`programming-essay`](./skills/programming-essay/SKILL.md) | Write programming essays in the voice of the canon — Spolsky, Yegge, Graham, Nystrom, Brooks |

--- a/skills/nix-playwright/SKILL.md
+++ b/skills/nix-playwright/SKILL.md
@@ -7,7 +7,7 @@ description: Use this when adding Nix-based local runs for an existing Playwrigh
 
 For projects that already have a Playwright e2e suite (typically under `tests/`) and need it to run locally on NixOS / pure-Nix hosts, where Playwright's bundled Chromium download depends on `apt-get` + `sudo`.
 
-CI is left untouched — apt-provided Chromium on Ubuntu runners is cheaper than spinning up a Nix devshell. This skill is for **local** runs only.
+GitHub Actions CI is left untouched — apt-provided Chromium on Ubuntu runners is cheaper than spinning up a Nix devshell. This skill is for **local** runs (and Nix-based CI like Vira); GHA continues to use its own apt path.
 
 ## Add a `nixpkgs-latest` flake input
 

--- a/skills/nix-playwright/SKILL.md
+++ b/skills/nix-playwright/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: nix-playwright
+description: Use this when adding Nix-based local runs for an existing Playwright e2e suite. Provides a self-contained `tests/shell.nix` that uses `nixpkgs-latest` for `playwright-driver.browsers`, plus a justfile entry — works on NixOS where `npx playwright install --with-deps` cannot.
+---
+
+# Playwright e2e under Nix
+
+For projects that already have a Playwright e2e suite (typically under `tests/`) and need it to run locally on NixOS / pure-Nix hosts, where Playwright's bundled Chromium download depends on `apt-get` + `sudo`.
+
+CI is left untouched — apt-provided Chromium on Ubuntu runners is cheaper than spinning up a Nix devshell. This skill is for **local** runs only.
+
+## Add a `nixpkgs-latest` flake input
+
+In top-level `flake.nix`, add an independent pin so the Playwright rev moves on its own cadence (decoupled from the main `nixpkgs` your build uses):
+
+```nix
+inputs.nixpkgs-latest.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+```
+
+## `tests/shell.nix`
+
+Self-contained. Reads the parent flake's lock to resolve `nixpkgs-latest` without needing a flake context:
+
+```nix
+let
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+  nixpkgsLocked = lock.nodes.nixpkgs-latest.locked;
+  pkgs = import (builtins.fetchTree {
+    type = "github";
+    inherit (nixpkgsLocked) owner repo rev narHash;
+  }) { };
+in
+pkgs.mkShell {
+  packages = [ pkgs.nodejs ];
+  PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+}
+```
+
+## Justfile recipe
+
+```just
+e2e:
+    nix-shell tests/shell.nix --run "cd tests && { [ -d node_modules ] || npm ci; } && npm test"
+```
+
+## Critical version constraint
+
+`pkgs.playwright-driver` version must match the `playwright` version in `tests/package.json`. Drift raises **"browser revision X not found at <PLAYWRIGHT_BROWSERS_PATH>"** at launch.
+
+Bump both together:
+
+1. `nix flake update nixpkgs-latest`
+2. Match `playwright` in `tests/package.json` to the new driver version
+3. `npm install` in `tests/` to regenerate the lockfile
+
+## Reference
+
+Pattern extracted from [emanote#660](https://github.com/srid/emanote/pull/660).


### PR DESCRIPTION
## Summary
- New `nix-playwright` skill capturing the pattern from [srid/emanote#660](https://github.com/srid/emanote/pull/660) for running an existing Playwright e2e suite locally on NixOS / pure-Nix hosts
- Covers the `nixpkgs-latest` flake input, a self-contained `tests/shell.nix` that reads the parent lock to provide `playwright-driver.browsers` + `PLAYWRIGHT_BROWSERS_PATH`, and a justfile entry
- Flags the critical driver ↔ npm `playwright` version coupling (drift triggers "browser revision X not found")

## Test plan
- [ ] Verify SKILL.md frontmatter and table entry render
- [ ] Apply skill to a project with an existing Playwright suite and confirm `just e2e` works on NixOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)