### PR TITLE
Add nix-perf skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 | [`nix-haskell`](./skills/nix-haskell/SKILL.md) | Haskell projects with haskell-flake: dependencies, settings, devShell, autoWire |
 | [`nix-health`](./skills/nix-health/SKILL.md) | Diagnosing Nix installation health — flakes, version, caches, max-jobs, direnv, and shell config |
 | [`nix-justfile`](./skills/nix-justfile/SKILL.md) | Conventions for writing justfile recipes in Nix-based projects |
+| [`nix-perf`](./skills/nix-perf/SKILL.md) | Diagnosing slow first-fetch (`direnv allow` / `nix flake archive`) — lockfile inspection, `follows` patterns, and cold-fetch measurement |
 | [`nix-playwright`](./skills/nix-playwright/SKILL.md) | Run an existing Playwright e2e suite locally on NixOS via `tests/shell.nix` + justfile |
 | [`nix-rust-leptos`](./skills/nix-rust-leptos/SKILL.md) | Conventions for building Leptos CSR apps with Nix (crane + Trunk) |
 | [`nix-typescript`](./skills/nix-typescript/SKILL.md) | pnpm + Nix build conventions — fetchPnpmDeps hash management and dependency workflow |

--- a/skills/nix-perf/SKILL.md
+++ b/skills/nix-perf/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: nix-perf
+description: Use this when a flake's `nix develop` / `direnv allow` / `nix flake archive` is slow on a fresh checkout (the "first time takes 10 minutes" complaint). Diagnoses where the time actually lives and how to shrink the flake.lock input graph without changing build outputs.
+---
+
+# Diagnosing slow flake first-fetch
+
+## Triage which operation is actually slow
+
+Before optimizing anything, pin down which command the user runs and time each on a **fresh** state (cleared eval cache + cold `/nix/store` for an honest measurement):
+
+| Command | What it does | Bottleneck |
+|---|---|---|
+| `nix develop --command true` | Lazy: fetches only inputs whose outputs the devShell eval touches | Eval + minimal substitution |
+| `nix print-dev-env` | Same laziness as above; what plain nix-direnv `use flake` invokes | Same as above |
+| `nix flake archive --no-write-lock-file` | Eager: fetches every node in flake.lock into the store | Total lock-graph size |
+| `nix build .#default` | Eval + realize closure | Eval + builds not in cache |
+
+The "direnv takes 10 minutes" complaint usually maps to `nix flake archive` (nix-direnv with input pre-caching enabled, or wrappers that warm the store for offline use), not to `nix print-dev-env`. **Confirm which one is slow before you start optimizing** — lazy eval is invariant to lockfile bloat; eager archive isn't.
+
+## Inspect lockfile shape
+
+Use `nix run nixpkgs#jq` on `flake.lock` to extract:
+
+- **Total node count** (`.nodes | keys | length`) — gross size of the input graph
+- **Unique `narHash` count** (`[.nodes[].locked.narHash] | unique | length`) — actual number of distinct sources nix would fetch on a cold machine. Duplicate nodes pointing at the same store path don't add fetches.
+- **Top duplicated repos** — group nodes by `original.repo` / `original.url`, sort by count. Many copies of `nixpkgs`, `flake-utils`, `flake-parts`, `nix-systems/default` is normal; very large counts mean missing `follows`.
+- **Recursion / self-cycles** — search for any input whose downstream lists the current flake (or an older tag of it) as one of *its* inputs. The lockfile resolver expands these into N stacked copies and explodes transitively. This is the single biggest cause of pathological flake.lock blow-up in practice.
+
+## Reduce the graph with `follows`
+
+For each transitive duplicate that has a sibling at the root, add `inputs.X.inputs.Y.follows = "Y"`. You can chain: `inputs.A.inputs.B.inputs.C.follows = "C"`. The rules:
+
+- **Safe**: pointing a downstream's dev-tooling (`flake-parts`, `flake-utils`, `git-hooks-nix`, `treefmt-nix`, `fourmolu-nix`, `nix-systems`) at the root's copy. These are eval-only and version-tolerant.
+- **Safe**: collapsing a self-recursion. If `foo` lists `your-flake` as an input, follow the inner `your-flake`'s sub-inputs back to the root (`inputs.foo.inputs.your-flake.inputs.bar.follows = "bar"`). Also follow `inputs.foo.inputs.your-flake.inputs.foo.follows = "foo"` to break the recursion at one level.
+- **Risky**: re-following a downstream's `nixpkgs` or `haskell-flake` to a *different revision* than what its lockfile pinned. This changes hash propagation and triggers cabal/Haskell rebuilds. Only do it if you're explicitly bumping that downstream.
+- **Useless**: following inputs that the downstream resolves to the same `narHash` you'd pick anyway. Lockfile gets renumbered, fetch count doesn't change.
+
+After each change run `nix flake lock` and re-measure both node count and unique-narHash count. Commit only changes that move the unique-narHash number.
+
+## Measurement methodology
+
+For cold-fetch numbers, use a fresh VM. On juspay infrastructure: `pu create --name X`, ship the repo snapshot with `git archive <ref> | ssh X 'tar -x -C /tmp/...'`, time the operation, then `pu destroy X` and recreate for the next sample so `/nix/store` starts empty. Don't try to simulate cold by deleting paths from a live `/nix/store` — the nix-daemon protects flake-input paths as live roots and `--ignore-liveness` doesn't always evict them.
+
+For eval-only numbers (no fetch), keep `/nix/store` warm and clear `~/.cache/nix/eval-cache-v*` between runs. Median of 3–5 runs.
+
+Always record both numbers separately. Eval improvements and fetch improvements look very different and conflating them produces misleading PR descriptions.
+
+## Diminishing returns
+
+Stop optimizing when the remaining lockfile duplicates are at *distinct* revisions (different repos pinning different `nixpkgs` revs, for instance). Further consolidation requires bumping inputs, which is a separate decision from input-graph hygiene.
+
+## Companion docs
+
+- `nix-flake` (this repo) — flake.nix structure conventions
+- `nix-health` (this repo) — substituters, max-jobs, trusted-users checks that also gate first-fetch speed
+- [Flakes reference: input attributes](https://nix.dev/manual/nix/2.31/command-ref/new-cli/nix3-flake.html#flake-inputs) — `follows`, `flake = false`, etc.


### PR DESCRIPTION
## Summary
- New `nix-perf` skill capturing the diagnostic playbook for the "first-fetch / `direnv allow` takes 10 minutes" complaint on flakes with bloated input graphs.
- Focuses on triaging which operation is actually slow (lazy `nix print-dev-env` vs eager `nix flake archive`), inspecting `flake.lock` shape, applying `follows` safely, and measuring cold-fetch honestly on a fresh VM.

## Motivation
Comes from a real run on `juspay/euler-lsp`: lockfile went 1904 → 356 nodes (−81%) and unique narHashes 273 → 172 (−37%) after breaking a self-recursion (`euler-lsp-api-gateway` listing `euler-lsp` itself as one of its inputs, expanded 7 levels deep). Measured on fresh `pu` VMs, `nix flake archive` cold dropped from **9 min → 4 min 40 s** (−48%). `nix print-dev-env` was unchanged at ~21 s because it's lazy. That experience generalises into the skill.

## Test plan
- [ ] Skill renders correctly on GitHub
- [ ] Triggers on prompts like "nix develop is slow on first checkout"
- [ ] Doesn't trigger on routine `flake.nix` authoring (that's `nix-flake`)