### PR TITLE
Add the pg skill — write in Paul Graham's voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 | [`nix-playwright`](./skills/nix-playwright/SKILL.md) | Run an existing Playwright e2e suite locally on NixOS via `tests/shell.nix` + justfile |
 | [`nix-rust-leptos`](./skills/nix-rust-leptos/SKILL.md) | Conventions for building Leptos CSR apps with Nix (crane + Trunk) |
 | [`nix-typescript`](./skills/nix-typescript/SKILL.md) | pnpm + Nix build conventions — fetchPnpmDeps hash management and dependency workflow |
+| [`pg`](./skills/pg/SKILL.md) | Write essays, articles, and blog posts in Paul Graham's voice — plain, spoken prose that reasons out loud, not AI filler |
 | [`programming-essay`](./skills/programming-essay/SKILL.md) | Write programming essays in the voice of the canon — Spolsky, Yegge, Graham, Nystrom, Brooks |
 | [`vhs`](./skills/vhs/SKILL.md) | Deterministic terminal demo screencasts with VHS and wait patterns |
 

--- a/skills/pg/SKILL.md
+++ b/skills/pg/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: pg
+description: >-
+  Write essays, articles, and blog posts in Paul Graham's voice — plain,
+  spoken prose that reasons out loud and lands surprising true claims, not
+  AI filler. Use when asked to write or rewrite something "like Paul
+  Graham", "in PG's style", or to make a piece read like a person thinking
+  on the page rather than generated text. Built from a stylistic model of
+  18 of his essays (see SOURCES.md).
+argument-hint: "<topic, or a draft to rewrite in PG's style>"
+---
+
+# Write Like Paul Graham
+
+Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." First settle the inline-format house style (below), write the piece in that voice, then revise out the AI tells using the checks further down.
+
+## First, pick an inline-format
+
+PG's own prose uses almost no inline emphasis — but a blog post usually wants a few scan anchors, and how heavy to go is the reader's call, not yours. So before you write (or before a rewrite pass), ask the user with the **AskUserQuestion** tool which house style to apply. Offer these four, in this order, and attach a `preview` of the same short snippet rendered under each so they can compare:
+
+1. **Bold takeaway + italic terms** _(recommended default)_ — one bold punchline per section, the single line the eye should catch, plus `_italic_` on a coined or key term's _first_ mention only. About one bold per section. Stays mostly PG-plain.
+2. **Bold lead-ins (definition style)** — open key sentences and list items with a bold label, so concepts scan down the left edge. Most skimmable, least PG; reads like docs.
+3. **Italics only (PG-light)** — `_italic_` for term-introduction and contrast, no bold at all. Closest to PG's own habit.
+4. **Code spans + structure only** — no bold or italic. Scannability comes from `##` headers, `>` blockquotes, and `` `identifier` `` code spans. Purest PG, lowest skim-ability.
+
+If the user doesn't care, default to option 1. Whichever they pick, apply it consistently and keep it sparing: emphasis on every line is emphasis on none. Never bold a whole paragraph — bold at most one sentence, and make it the takeaway. Italicize a term only on its first use.
+
+## The voice
+
+Sound like a smart friend explaining something at a bar, not a writer performing. Reason out loud in front of the reader: start from one plain observation, hit a snag, correct yourself, and land on a claim that feels like a thing you both just discovered rather than a thesis you walked in holding. Keep the prose short, flat, and Anglo-Saxon, so the rare crude or vivid word lands hard. Concede the obvious objection, then turn it over. Talk straight to "you." Hedge with "I think" and "my guess is" exactly where a weaker writer would bluff. And pin every abstraction to something physical — a leaking roof, 52 weekends, a hand-crank engine. The whole move is reducing a big mysterious thing to one mundane sentence.
+
+## Sentence mechanics
+
+- Default to short, plain declaratives. Then vary length on purpose: build a long clause-stacked sentence, then chase it with a two-to-four word verdict. "Hard, but doable." "That's nonsense."
+- Use fragments as punctuation for emphasis. A single word standing alone: "Why?" "I wish." "Then I had kids."
+- Open sentences with conjunctions constantly — And, But, So, Plus, Or, Yet, Indeed, Which. This is load-bearing connective tissue, not a flourish.
+- Lean on parataxis: set independent statements side by side instead of nesting clauses. The argument advances by addition.
+- Reserve the em-dash for two jobs only: an abrupt mid-sentence aside, and a reversal that refines what you just said.
+- Use parentheticals for a second thought or a deadpan correction. "(But she never does.)"
+- Use the colon as a pivot from setup to payoff, often to deliver the thesis itself.
+- Render lists as semicolon-chained vignettes or stacked imperatives, roughly equal in length, building toward a punchline.
+
+## Diction
+
+- Default to plain, monosyllabic, Anglo-Saxon words. When you must use an abstraction, cash it out immediately in a concrete image or a named example.
+- Allow exactly one sharp or crude word per stretch — "suck," "bullshit," "crap" — and let it land because everything around it is so plain. Crudeness is a precision tool, not a register.
+- Ground everything in concrete nouns and brand names: Aeron chairs, rolly bags, 52 weekends, Baskin-Robbins, a 4K TRS-80. The props do the persuading.
+- Drop a technical or scholarly term only when it's the precise word, and don't over-explain it. Gloss lightly if at all.
+- Use contractions everywhere. It's spoken language on the page.
+- Address the reader as "you," as a specific person facing the choice. Slide between "you," "one," and a raw first-person "I" confession.
+- Coin your own term and then wield it as if it always existed ("the Blub paradox," "maker's schedule").
+- Use precise-sounding numbers as anchors: "ahead of 95% of writers," "52 weekends," "67 minutes."
+- Reach for the homely "X is the Y of Z" equation: "Informal language is the athletic clothing of ideas."
+
+## How an essay is built
+
+An essay is something you write to figure something out, so build it as live reasoning, not a delivered conclusion. Don't open with the thesis you'll prove; open with a question or observation that genuinely puzzles you, and let the real thesis emerge late — often after you float a wrong guess and knock it down ("One possible explanation is... But this isn't true"). The shape is wander-then-converge: meander through facets, examples, and digressions, then pull the threads together in a final movement. You can even confess the wandering. Plant one governing analogy early (the hand-crank engine, sailing upwind) and return to it as the spine. For longer pieces, chunk under short bare section headers — often one word — and inside each run the same loop: state the principle, anchor it in a named real example, extract the lesson. Push qualifications and attributions into endnotes so the main line stays clean. Where you can, let the essay enact its thesis: a piece about brevity is brief; a piece about discovery visibly discovers.
+
+## Openings
+
+- State a flat, deflationary thesis as bare fact, then immediately complicate it. "Life is short, as everyone knows. Is life actually short...?"
+- Open on a concrete autobiographical scene or dated memory that postpones the argument and earns trust first. "When I finished grad school I went to art school to study painting."
+- Ask the reader a direct, conspiratorial question that assumes shared complicity. "Remember the essays you had to write in high school?"
+- Concede a cliché, then interrogate whether it's actually true.
+- Narrate the moment of insight. "I finally realized today why..."
+- Offer a "trick" or recipe and deliver the whole thesis before the second sentence.
+- No throat-clearing. The hook is in the first sentence or two.
+
+## Endings
+
+- Collapse the argument into a compressed triad of imperatives or a single rule of thumb, then loop back to the opening, now earned.
+- Throw a rhetorical question back at the reader as a dare. "How hard is that?" "Why not by you?"
+- Zoom out from the specifics to a wider historical or moral view, landing hopeful and forward-looking.
+- Refuse the grand finish. Deflate into something modest, wry, or practical — a small ask, a deadpan tip.
+- Resolve the governing analogy one last time so the metaphor closes the loop.
+- Land a single sharp aphorism and stop, pushing any softening counter-case into a footnote.
+- Swerve from sober candor to brisk encouragement and hand agency back. "If you want to do it, do it."
+
+## Rhetorical moves
+
+- Concession-then-reversal — the workhorse. Grant the objection generously, then turn it. "On the whole his advice is good... But there is a contradiction."
+- Voice the reader's objection in their own words, often as a quoted question, then answer it. "Really? How do you make them?"
+- Pose a rhetorical question and answer it curtly. "How do you figure out what customers want? Watch them."
+- Reframe the question itself from first principles — not "is this taking over the world" but "how big could it get if the founders did the right things."
+- State a surprising claim flatly, as if obvious. "Prestige is just fossilized inspiration."
+- Use the "X is just Y" / "X is really Y" reframe to deflate a mystified abstraction into something mundane.
+- Use "not X, but Y" to sharpen a claim — surgically, to correct one misconception, never as filler.
+- Hedge deliberately — "I think," "my guess is," "probably," "I suspect" — placed exactly where bluffing would be tempting.
+- Use an extended analogy as the actual argument, not decoration; sometimes dismantle it later. "This metaphor doesn't stretch that far."
+- Lower your own status for credibility. "We felt pretty lame at the time."
+- Drop a deadpan aside that punctures the prose. "we, ah, skipped all that."
+
+## Never do this (the AI tells)
+
+- Rule-of-three everywhere. Don't force every list and adjective into tidy triads. Let a list be as long as the idea needs — two beats, four, or a long semicolon-chained set of vignettes. A clipped "Hard, but doable." beats a forced triad.
+- "Not just X, but Y" as a profundity cadence. Use the reframe only to correct a specific misconception, where it does real argumentative work.
+- Bullet lists standing in for argument. Even catalog essays run as headed prose. Each section states a principle, anchors it in a named company, extracts a lesson. Argue in sentences.
+- Hedging filler that means nothing ("it could be argued," "to some extent," "in many ways"). Hedge instead with content-bearing markers that report your actual confidence: "I think," "my guess is," "three reasons, I think."
+- Mechanical signposting ("Firstly... Moreover... In conclusion"). Connect with And, But, So, Plus, Which, Indeed, and transition by posing a question and answering it.
+- Over-balanced both-sides paragraphs that commit to nothing. Run concession-then-reversal instead: grant the view in a clause, overturn it, take a side.
+- The upbeat summarizing kicker that restates everything. End on a swerve, a dare, a deadpan joke, or a bare aphorism. Don't recap.
+- The "—and that's okay" reassuring register. Be candidly unsparing; let the hard fact stand. Reserve encouragement for a dare, not a pat on the head.
+- Em-dashes as a thoughtful-pause tic, two or three a paragraph. Use short fragments and parenthetical corrections for your pauses; save the dash for a genuine reversal.
+- Smooth uniform sentence length. Vary violently: a long clause-stacked sentence slammed against a two-word verdict. The terseness is the voice.
+- Abstract-to-abstract argument. If a paragraph has no physical object in it, it isn't his. Pin every abstraction to a noun, brand, or image the moment it appears.
+- Throat-clearing intros ("In today's fast-paced world..."). State the whole thesis in the first sentence or two and start arguing.
+- Scrubbing the prose corporate-neutral. Keep the plain register and let one blunt word land for jolt.
+- Vague authority ("studies show," "experts agree"). Argue from named first-hand evidence and your own war stories, or derive the claim from first principles in front of the reader.
+- Fence-sitting non-claims ("the answer is nuanced," "it depends"). State the surprising claim flatly as fact and defend it. A real thesis can be wrong.
+- Self-importance. Open by lowering your own status with a self-deprecating confession; it buys the right to make bold claims later.
+
+## Banned words & phrases
+
+`delve`, `delve into`, `tapestry`, `rich tapestry`, `underscore`, `underscores the importance`, `testament`, `a testament to`, `navigate`, `navigate the landscape`, `navigate the complexities`, `it's important to note`, `it's worth noting`, `in today's world`, `in today's fast-paced world`, `in the modern era`, `at its core`, `at the heart of`, `the world of`, `the realm of`, `realm`, `leverage`, `leveraging`, `robust`, `crucial`, `pivotal`, `vital`, `moreover`, `furthermore`, `additionally`, `in addition`, `consequently`, `thus`, `hence`, `in conclusion`, `to conclude`, `to sum up`, `in summary`, `ultimately`, `unlock`, `unleash`, `harness`, `harness the power of`, `elevate`, `embark`, `embark on a journey`, `journey`, `foster`, `cultivate`, `myriad`, `plethora`, `a plethora of`, `vast array`, `landscape`, `the landscape of`, `ever-evolving`, `ever-changing`, `rapidly evolving`, `game-changer`, `game-changing`, `paradigm`, `paradigm shift`, `synergy`, `holistic`, `seamless`, `seamlessly`, `cutting-edge`, `state-of-the-art`, `intricate`, `intricacies`, `multifaceted`, `nuanced`, `nuance`, `comprehensive`, `facilitate`, `utilize`, `endeavor`, `showcase`, `encompass`, `underpin`, `spearhead`, `transformative`, `groundbreaking`, `revolutionize`, `empower`, `resonate`, `resonates with`, `speaks volumes`, `the key takeaway`, `key takeaways`, `let's dive in`, `dive in`, `deep dive`, `first and foremost`, `last but not least`, `when it comes to`, `in the grand scheme of things`, `needless to say`, `at the end of the day`, `the fact of the matter is`, `it goes without saying`, `play a role`, `play a pivotal role`, `shed light on`, `pave the way`, `stand the test of time`, `boasts`, `treasure trove`, `bustling`, `stark contrast`, `stark reminder`, `indelible`, `profound`, `profoundly`, `captivating`, `compelling narrative`, `rich history`, `in essence`, `essentially` (as filler), `fundamentally` (as filler)
+
+## Process
+
+1. Start from a real observation or a question that genuinely puzzles you — something you don't already have the answer to. If you know the conclusion before you write, you'll preach instead of think.
+2. Write a bad version 1 as fast as you can, in spoken language — the way you'd explain it to a friend at a bar. Don't try to sound impressive.
+3. Follow the idea where it leads. Open a door that's ajar and walk in. If a digression is more interesting than your plan, take it; the plan was a guess.
+4. Find the surprising true thing. Interesting means surprise. Keep pushing past the first obvious answer until you hit a claim that's both true and not what you expected to say.
+5. Ground it. Go back through and pin every abstraction to a concrete noun, brand, person, or number. Cut any paragraph that floats free of the physical world.
+6. Cut everything that sounds like writing. Read each sentence and ask whether you'd actually say it out loud. If you hear the clank as it hits the page, rewrite it the way you'd speak it.
+7. Vary the rhythm. Slam your long sentences against short verdicts. Add the fragment that lands the point.
+8. End where the thought ends. When an ending appears, grab it. Don't sum up — swerve, dare, or land an aphorism and stop.
+
+## Revision checklist
+
+- [ ] Read the whole thing aloud. Did I hear a clank anywhere — a sentence I'd never actually say?
+- [ ] Would PG use this word? Run every fancy word against the banned list and swap it for the plain one.
+- [ ] Did I signpost ("Firstly," "Moreover," "In conclusion")? Cut it and connect with And/But/So or a question.
+- [ ] Is there a needless summary paragraph at the end? Delete it and end on the swerve.
+- [ ] Is every sentence load-bearing? If a sentence only restates the last one or only sounds nice, cut it.
+- [ ] Does each paragraph touch a physical object, name, or number? If not, ground it.
+- [ ] Is the rhythm bimodal, or are all my sentences the same medium length? Add a two-word verdict.
+- [ ] Did I concede-then-reverse, or did I just present both sides and commit to nothing?
+- [ ] Did I hedge with content ("my guess is") rather than filler ("it could be argued")?
+- [ ] Are my lists forced triads? Let them run to the length the thought needs.
+- [ ] Did I bury the thesis behind throat-clearing, or is it live in the first sentence or two?
+- [ ] Is there at least one blunt or crude word landing against the plain backdrop?
+- [ ] Did I argue from named, first-hand evidence rather than "studies show"?
+- [ ] Did I state a real, falsifiable claim, or did I fence-sit?
+- [ ] Did I apply the agreed inline-format consistently — bold only the section takeaway, italics only on a term's first use, and nothing on every line?
+
+## Calibration — real PG cadences
+
+For ear-calibration only. Don't copy these.
+
+> An essay is something you write to try to figure something out. (The Age of the Essay)
+
+> When you write something you wouldn't say, you'll hear the clank as it hits the page. (Write Like You Talk)
+
+> Then I had kids. (Life is Short)
+
+> Prestige is just fossilized inspiration. (How to Do What You Love)
+
+> Build something users love, and spend less than you make. How hard is that? (How to Start a Startup)
+
+> In technology, the low end always eats the high end. (How to Start a Startup)
+
+> Tim Cook doesn't send you a hand-written note after you buy a laptop. He can't. But you can. (Do Things that Don't Scale)
+
+> It was like being told to use dry water. (How to Do What You Love)
+
+> Both of these images are wrong. (Hackers and Painters)
+
+> I learned that I don't exist. (How to Do Philosophy)

--- a/skills/pg/SOURCES.md
+++ b/skills/pg/SOURCES.md
@@ -1,0 +1,32 @@
+# Sources & method
+
+The `pg` skill was built by scraping a diverse sample of Paul Graham's essays from <https://paulgraham.com/articles.html> (via `curl`), analyzing each one for *how* it is written (openings, sentence rhythm, diction, rhetorical moves, endings), and synthesizing a cross-essay voice model plus an anti-AI ruleset. This file records what was sampled so the model is auditable and refreshable.
+
+## Essays sampled (18)
+
+- [How to Start a Startup](https://paulgraham.com/start.html)
+- [Do Things that Don't Scale](https://paulgraham.com/ds.html)
+- [The Age of the Essay](https://paulgraham.com/essay.html)
+- [Write Like You Talk](https://paulgraham.com/talk.html)
+- [Writing, Briefly](https://paulgraham.com/writing44.html)
+- [Life is Short](https://paulgraham.com/vb.html)
+- [How to Do Philosophy](https://paulgraham.com/philosophy.html)
+- [How to Do What You Love](https://paulgraham.com/love.html)
+- [Hackers and Painters](https://paulgraham.com/hp.html)
+- [Beating the Averages](https://paulgraham.com/avg.html)
+- [The Hundred-Year Language](https://paulgraham.com/hundred.html)
+- [What You Can't Say](https://paulgraham.com/say.html)
+- [How to Disagree](https://paulgraham.com/disagree.html)
+- [Keep Your Identity Small](https://paulgraham.com/identity.html)
+- [Why Nerds are Unpopular](https://paulgraham.com/nerds.html)
+- [What You'll Wish You'd Known](https://paulgraham.com/hs.html)
+- [How to Do Great Work](https://paulgraham.com/greatwork.html)
+- [Maker's Schedule, Manager's Schedule](https://paulgraham.com/makersschedule.html)
+
+## Voice model (distilled)
+
+He sounds like a smart friend explaining something at a bar, not a writer performing. The trick is that he reasons out loud in front of you: he starts from one plain observation, hits a snag, corrects himself, and lands on a claim that feels like a discovery you made together rather than a thesis he came in with. The prose is mostly short, flat, Anglo-Saxon sentences, and the few vivid or crude words (suck, bullshit, fossilized inspiration) land harder because everything around them is so plain. He's constantly conceding the obvious objection, then turning it over — "Maybe, but probably not" — which makes the bold claims feel earned instead of arrogant. He talks straight to "you," hedges with "I think" and "my guess is" exactly where a lesser writer would bluff, and grounds every abstraction in something physical: a leaking roof, 52 weekends, a hand-crank engine. And he keeps reducing big mysterious things to a single mundane sentence — that's the whole move.
+
+## Refreshing the model
+
+Re-run the `pg-style-model` workflow (it curls the index, picks a diverse set, analyzes each essay in parallel, and re-synthesizes the voice model + anti-AI tells). Then regenerate the runtime skill dirs with `just ai::apm`.


### PR DESCRIPTION
**Adds `pg`, a skill that writes (or rewrites) essays, articles, and blog posts in Paul Graham's voice** — plain, spoken prose that reasons out loud and lands a surprising true claim, instead of the smooth, signpost-laden register that reads as AI-generated. It was built empirically, from a stylistic model of 18 of his essays (recorded in `SOURCES.md` for auditability).

### What's in it

`SKILL.md` is an imperative playbook, not a description: the voice, sentence mechanics, diction, how an essay is built, openings/endings, rhetorical moves, a **"never do this" AI-tells** section, a ~120-item **banned-word list** (`delve`, `leverage`, `in conclusion`, …), an 8-step process, a revision checklist, and a calibration set of real PG quotes. It opens by asking — via `AskUserQuestion` — which inline-format house style to apply (bold-takeaway + italic-terms, bold lead-ins, italics-only, or code-spans-and-structure), so it doesn't guess.

### Relationship to `programming-essay`

They're complementary, not redundant:

| Skill | Scope |
| --- | --- |
| `programming-essay` | the broad **canon** voice — Spolsky, Yegge, Graham, Nystrom, Brooks… — for arguing an idea about software |
| `pg` *(this PR)* | the deep, **single-author** cut, for when you specifically want Paul Graham, on any topic (not just programming) |

### Conventions

- `name: pg` matches the directory; frontmatter has `name` + `description` (a "use this when…" trigger).
- No fenced code examples; the calibration quotes are short blockquotes.
- Added to the `README.md` skills table (between `nix-typescript` and `programming-essay`).

Proven in use: it rewrote all four posts on [Kolu's blog](https://github.com/juspay/kolu/tree/master/website/src/content/blog). Once this merges, Kolu will consume it via `juspay/skills/skills/pg` instead of carrying a local copy.

_Generated by Claude Code (model `claude-opus-4-8`)._