### PR TITLE
Add nix-bun skill and document /nix/store caching in nix-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 
 | Skill | Description |
 |-------|-------------|
+| [`nix-bun`](./skills/nix-bun/SKILL.md) | Bun + Nix via bun2nix — bun.nix dependency workflow, the `bun --compile` pitfall, CI drift check |
 | [`nix-ci`](./skills/nix-ci/SKILL.md) | CI setup for GitHub repos — GitHub Actions or Vira |
 | [`nix-for-dev`](./skills/nix-for-dev/SKILL.md) | Fast `nix develop` setup — zero-inputs `flake.nix`, npins, sub-flakes for non-user-facing Nix |
 | [`nix-haskell`](./skills/nix-haskell/SKILL.md) | Haskell projects with haskell-flake: dependencies, settings, devShell, autoWire |

--- a/skills/nix-bun/SKILL.md
+++ b/skills/nix-bun/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: nix-bun
+description: Use this when building a Bun (bun.lock) project with Nix. Covers bun2nix, the bun.nix dependency workflow, the bun --compile top-level-await pitfall, and a CI drift check.
+---
+
+# Bun + Nix with bun2nix
+
+For Bun projects (those with a `bun.lock`), use [bun2nix](https://github.com/nix-community/bun2nix) — it converts the lockfile into a `bun.nix` expression so Nix installs dependencies deterministically and offline. Keep nixpkgs pinned via npins (see `nix-for-dev`) and add bun2nix as the single flake input.
+
+## Dependency workflow
+
+`bun.nix` is generated and must track `bun.lock`. Regenerate it whenever dependencies change:
+
+```bash
+nix run github:nix-community/bun2nix -- -o bun.nix
+```
+
+Pin the same bun2nix version in `flake.nix` (`?ref=2.1.0`) and in CI so generation is reproducible.
+
+## Building
+
+Idiomatic usage compiles a standalone binary:
+
+```nix
+# default.nix
+{ bun2nix, ... }:
+bun2nix.mkDerivation {
+  pname = "myapp";
+  version = "1.0.0";
+  src = ./.;
+  bunDeps = bun2nix.fetchBunDeps { bunNix = ./bun.nix; };
+  module = "src/index.ts";   # entrypoint compiled into `bin/myapp`
+}
+```
+
+`bun2nix.packages.<system>.default` carries `mkDerivation`, `fetchBunDeps`, and `hook` as passthru attrs, so you can use it without a flake-parts overlay.
+
+### Pitfall: `bun build --compile` is fragile
+
+`mkDerivation { module = ...; }` runs `bun build --compile`, which **fails on top-level `await`** (`error: "await" can only be used inside an "async" function`) and can produce a broken binary for apps with **native addons or workers**. (`bun run` handles all of these — only the bundler chokes.)
+
+When `--compile` doesn't work, build a wrapper that runs the entrypoint with `bun` instead, using bun2nix only for deterministic deps:
+
+```nix
+{ pkgs, bun2nix, ... }:
+pkgs.stdenv.mkDerivation {
+  pname = "myapp"; version = "1.0.0"; src = ./.;
+  nativeBuildInputs = [ bun2nix.hook pkgs.makeWrapper ];  # hook populates node_modules offline
+  bunDeps = bun2nix.fetchBunDeps { bunNix = ./bun.nix; };
+  # buildPhase: build any workspace deps (tsc) the entrypoint imports
+  installPhase = ''
+    appdir=$out/share/myapp
+    mkdir -p $appdir $out/bin
+    cp -R src package.json node_modules $appdir/
+    makeWrapper ${pkgs.bun}/bin/bun $out/bin/myapp --add-flags "run $appdir/src/index.ts"
+  '';
+  dontFixup = true;
+}
+```
+
+The bun2nix hook runs `patchShebangs`, but tsc's `/usr/bin/env node` shebang still breaks in the sandbox — invoke it as `bun ./node_modules/typescript/bin/tsc` instead of via the `.bin` symlink.
+
+## CI: keep bun.nix from drifting
+
+Add a check that fails when `bun.nix` is out of sync with `bun.lock`:
+
+```yaml
+- run: |
+    nix run github:nix-community/bun2nix/2.1.0 -- --lock-file ./bun.lock --output-file ./bun.nix
+    git diff --exit-code -- bun.nix \
+      || { echo "::error::bun.nix is stale — run: nix run github:nix-community/bun2nix -- -o bun.nix"; exit 1; }
+```
+
+This check is fast; run it as a separate job from the (slow) `nix build` so PRs get quick feedback. For the build job, cache `/nix/store` — see `nix-ci`.

--- a/skills/nix-ci/SKILL.md
+++ b/skills/nix-ci/SKILL.md
@@ -31,6 +31,39 @@ jobs:
       - run: vira ci
 ```
 
+### Caching the Nix store (plain `nix build`, no Vira)
+
+When building directly with `nix build` on GitHub runners (instead of `vira ci`), cache `/nix/store` across runs with [`cache-nix-action`](https://github.com/nix-community/cache-nix-action). Otherwise every run re-fetches all dependency tarballs and rebuilds the whole closure — easily 30 min for a large app. With a warm cache the build job drops to ~1 min (dominated by the restore).
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write          # REQUIRED — see gotcha 2 below
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v34
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', '**/flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G   # keep under the 10 GB repo cache limit
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+      - run: nix build -L
+```
+
+Two gotchas, each of which makes the cache **silently no-op** (save/restore complete in ~1s and nothing is cached):
+
+1. **`cache-nix-action` must pair with `nix-quick-install-action`, not the DeterminateSystems installer.** The DetSys daemon-based store layout isn't snapshotted by the cache action. (This is the concrete reason for "avoid DetSys actions" above.)
+2. **`purge: true` requires `actions: write` permission.** Without it the save aborts with `Resource not accessible by integration` (it calls the REST cache API to purge stale entries) and no `nix-*` cache is ever created.
+
+Verify it worked: `gh cache list` should show a `nix-*` entry sized in the hundreds-of-MB-to-GB range — not just the installer's own ~40 MB cache.
+
 ## Option 2: Vira Self-Hosted
 
 Vira is already running and pointed at the repo. Create a `vira.hs` file in the repo root to configure the build pipeline.


### PR DESCRIPTION
Captures two reusable lessons from packaging a Bun CLI with Nix and cutting its CI from **~30 min to ~1 min**.

### New: `nix-bun`

Fills the gap left by `nix-typescript` (pnpm-only). Covers building Bun (`bun.lock`) projects with [bun2nix](https://github.com/nix-community/bun2nix): the `bun.nix` regenerate-on-dependency-change workflow, and a CI check that fails when `bun.nix` drifts from `bun.lock`.

The non-obvious bit: **`bun2nix.mkDerivation { module = ...; }` (which runs `bun build --compile`) fails on top-level `await` and can produce a broken binary for apps with native addons or workers.** `bun run` handles all of these, so the skill shows the fallback — use bun2nix for deterministic deps (`fetchBunDeps` + `hook`) and wrap `bun run <entrypoint>` instead of compiling.

### Updated: `nix-ci`

Adds a `/nix/store` caching recipe for plain `nix build` on GitHub Actions (the non-Vira path), with the two gotchas that each make `cache-nix-action` a **silent ~1s no-op**:

1. It must pair with `nix-quick-install-action`, **not** the DeterminateSystems installer — which is the concrete reason behind the skill’s existing "avoid DetSys actions" advice.
2. `purge: true` needs `actions: write`, or the save aborts with `Resource not accessible by integration`.

Both were diagnosed and verified end-to-end (cold vs warm runs, `gh cache list` confirming a 1.77 GiB `nix-*` cache).

_Generated by the forge-pr skill on Claude Code (model claude-opus-4-8)._