### PR TITLE
Add nix-oss-cache skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AI skill pack — reusable [SKILL.md](https://opencode.ai/docs/skills/) definiti
 | [`nix-haskell`](./skills/nix-haskell/SKILL.md) | Haskell projects with haskell-flake: dependencies, settings, devShell, autoWire |
 | [`nix-health`](./skills/nix-health/SKILL.md) | Diagnosing Nix installation health — flakes, version, caches, max-jobs, direnv, and shell config |
 | [`nix-justfile`](./skills/nix-justfile/SKILL.md) | Conventions for writing justfile recipes in Nix-based projects |
+| [`nix-oss-cache`](./skills/nix-oss-cache/SKILL.md) | Set up a GitHub repo to push Nix builds to Juspay's shared OSS Attic cache (`cache.nixos.asia/oss`) |
 | [`nix-perf`](./skills/nix-perf/SKILL.md) | Diagnosing slow first-fetch (`direnv allow` / `nix flake archive`) — lockfile inspection, `follows` patterns, and cold-fetch measurement |
 | [`nix-playwright`](./skills/nix-playwright/SKILL.md) | Run an existing Playwright e2e suite locally on NixOS via `tests/shell.nix` + justfile |
 | [`nix-rust-leptos`](./skills/nix-rust-leptos/SKILL.md) | Conventions for building Leptos CSR apps with Nix (crane + Trunk) |

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -121,6 +121,29 @@ gh secret list --repo <owner>/<repo>   # ATTIC_TOKEN should appear
 
 If it's missing, tell them and ask again — loop until `gh secret list` shows `ATTIC_TOKEN`. The workflow fails loudly without this secret; there is no silent skip.
 
-## Verify
+## 4. Open a PR
 
-Push to the default branch (or trigger via **Actions → nix-cache → Run workflow**). A green run means the closure was pushed. To confirm the pull side works, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.
+Commit the `flake.nix` and workflow changes on a branch and open a PR:
+
+```bash
+gh pr create --title "Push Nix builds to the OSS Attic cache" --body "..."
+```
+
+The workflow's `pull_request` trigger means the run fires on the PR itself, so you get a green/red signal before merge — no need to merge blind.
+
+## 5. Monitor the run to success
+
+Watch the run and don't declare success until it's actually green:
+
+```bash
+gh run list --workflow nix-cache.yml --limit 1     # find the run
+gh run watch <run-id>                              # stream to completion
+```
+
+If it fails, diagnose with `gh run view <run-id> --log-failed` and fix. Common causes:
+
+- **`ATTIC_TOKEN` missing / unauthorized** — the secret isn't set or lacks push scope; loop back to step 3.
+- **Build failure** — `nix build` itself is broken; that's a repo problem, not a cache one. Fix the build.
+- **Unpinned-action / permissions warnings** — check the pins and `permissions:` block from step 2.
+
+A green run means the closure was pushed. To confirm the pull side, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -11,17 +11,12 @@ Three pieces are needed: the cache as a **substituter** (so the repo _pulls_ fro
 
 ## Initial setup questionnaire
 
-Before touching any files, use the **Ask tool** (`AskUserQuestion`) to gather both decisions up front:
+Before touching any files, use the **Ask tool** (`AskUserQuestion`) to settle the **trigger scope** — which branches should trigger a build-and-push?
 
-1. **Push token** — do you already have an `ATTIC_TOKEN` (a push token for the `oss` cache)?
-   - **Yes, I have it** — proceed; you'll set it as a secret in step 3.
-   - **Not yet** — the token is issued by the cache admin (Juspay infra) via `atticadm make-token`, scoped to push the `oss` cache. **Stop and get one from the maintainer/admin before continuing** — the workflow is useless without it.
+- **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
+- **All branches** — push on every branch too, so feature branches warm the cache. Costs more CI minutes and can push closures from unreviewed code.
 
-2. **Trigger scope** — which branches should trigger a build-and-push?
-   - **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
-   - **All branches** — push on every branch too, so feature branches warm the cache. Costs more CI minutes and can push closures from unreviewed code.
-
-Carry both answers into the steps below.
+Assume the user already has an `ATTIC_TOKEN` push token (they obtain it from the cache admin — Juspay infra — via `atticadm make-token`, scoped to the `oss` cache). Don't block on it here; step 3 confirms it's set on the repo and loops until it is.
 
 ## 1. Add the cache as a substituter
 
@@ -112,13 +107,19 @@ Rules:
 
 ## 3. Set the ATTIC_TOKEN secret
 
-Use the `ATTIC_TOKEN` from the questionnaire. **Prompt the user to run** (never paste the token into the repo or a command line that gets logged):
+The token is a repo secret you can't set for the user — it's their token, entered interactively so it stays out of shell history. **Give them this command and ask them to run it**, then confirm:
 
 ```bash
 gh secret set ATTIC_TOKEN --repo <owner>/<repo>
 ```
 
-`gh` prompts for the value interactively so it stays out of shell history. Confirm with `gh secret list --repo <owner>/<repo>` — the workflow fails loudly without this secret; there is no silent skip.
+`gh` prompts for the value interactively (never paste the token into a command line that gets logged). After they say they've run it, **re-check** and **re-ask until it's present**:
+
+```bash
+gh secret list --repo <owner>/<repo>   # ATTIC_TOKEN should appear
+```
+
+If it's missing, tell them and ask again — loop until `gh secret list` shows `ATTIC_TOKEN`. The workflow fails loudly without this secret; there is no silent skip.
 
 ## Verify
 

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -72,7 +72,6 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin.
-        # Drop macos-latest if the repo is Linux-only.
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,7 +99,6 @@ jobs:
 Rules:
 
 - For **default branch only**, set the `push.branches` filter to the repo's actual default branch (kolu uses `master`; many repos use `main`). For **all branches**, drop the `branches:` filter so `push:` fires everywhere.
-- Drop `macos-latest` from the matrix if the repo has no Darwin consumers — building on macOS runners is slower and often unnecessary.
 - Keep both actions **pinned by commit SHA** (CodeQL flags unpinned third-party actions). The `# v35` / `# v0.5.0` trailing comments record the tag. Prefer the SHAs above unless a newer release is needed; do not replace them with floating tags.
 
 ## 3. Set the ATTIC_TOKEN secret

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -29,6 +29,22 @@ Before writing the file, use the **Ask tool** (`AskUserQuestion`) to ask which b
 
 Set the `on:` triggers to match the answer. The template below is the default-branch-only variant.
 
+### Already have a `nix build` workflow? Piggyback on it.
+
+If the repo already has a workflow that runs `nix build` (e.g. a CI job), **don't add a second one** — just drop the `ryanccn/attic-action` step into the existing job, *before* the build step, so its end-of-job hook pushes whatever that job builds:
+
+```yaml
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
+```
+
+The action pushes every store path realised during the job, so no explicit push step is needed. Only create the standalone `nix-cache.yml` below when there's no existing build job to hook into. (Note: if the existing job uses the DeterminateSystems installer rather than `nix-quick-install-action`, verify attic-action still finds a new-enough Nix for `nix profile add`.)
+
+### Standalone workflow
+
 Create `.github/workflows/nix-cache.yml`. `ryanccn/attic-action` handles install, login, substituter config, and pushing every store path the job produced at job end.
 
 ```yaml

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -9,6 +9,20 @@ Wire a GitHub repo into the shared Attic cache at [`cache.nixos.asia/oss`](https
 
 Three pieces are needed: the cache as a **substituter** (so the repo _pulls_ from it), a **workflow** (so CI _pushes_ to it), and the **`ATTIC_TOKEN` secret** (so the push authenticates). Do all three.
 
+## Initial setup questionnaire
+
+Before touching any files, use the **Ask tool** (`AskUserQuestion`) to gather both decisions up front:
+
+1. **Push token** — do you already have an `ATTIC_TOKEN` (a push token for the `oss` cache)?
+   - **Yes, I have it** — proceed; you'll set it as a secret in step 3.
+   - **Not yet** — the token is issued by the cache admin (Juspay infra) via `atticadm make-token`, scoped to push the `oss` cache. **Stop and get one from the maintainer/admin before continuing** — the workflow is useless without it.
+
+2. **Trigger scope** — which branches should trigger a build-and-push?
+   - **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
+   - **All branches** — push on every branch too, so feature branches warm the cache. Costs more CI minutes and can push closures from unreviewed code.
+
+Carry both answers into the steps below.
+
 ## 1. Add the cache as a substituter
 
 In the repo's top-level `flake.nix`, add (or extend) `nixConfig`:
@@ -22,12 +36,7 @@ nixConfig = {
 
 ## 2. Add the workflow
 
-Before writing the file, use the **Ask tool** (`AskUserQuestion`) to ask which branches should trigger a build-and-push:
-
-- **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
-- **All branches** — push on every branch as well, so feature branches warm the cache too. Costs more CI minutes and can push closures from unreviewed code.
-
-Set the `on:` triggers to match the answer. The template below is the default-branch-only variant.
+Set the `on:` triggers to match the **trigger scope** answer from the questionnaire. The template below is the default-branch-only variant.
 
 ### Already have a `nix build` workflow? Piggyback on it.
 
@@ -103,9 +112,7 @@ Rules:
 
 ## 3. Set the ATTIC_TOKEN secret
 
-The token is a **push token** issued by the cache admin (Juspay infra) via `atticadm make-token`. Ask the maintainer/admin for one scoped to push the `oss` cache if you don't have it.
-
-Once the user has the token, **prompt them to run** (never paste the token into the repo or a command line that gets logged):
+Use the `ATTIC_TOKEN` from the questionnaire. **Prompt the user to run** (never paste the token into the repo or a command line that gets logged):
 
 ```bash
 gh secret set ATTIC_TOKEN --repo <owner>/<repo>

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -22,6 +22,13 @@ nixConfig = {
 
 ## 2. Add the workflow
 
+Before writing the file, use the **Ask tool** (`AskUserQuestion`) to ask which branches should trigger a build-and-push:
+
+- **Default branch only** — push on the default branch (`main`/`master`) plus `pull_request` and `workflow_dispatch`. Warms the cache from merged, reviewed code. Recommended for most repos.
+- **All branches** — push on every branch as well, so feature branches warm the cache too. Costs more CI minutes and can push closures from unreviewed code.
+
+Set the `on:` triggers to match the answer. The template below is the default-branch-only variant.
+
 Create `.github/workflows/nix-cache.yml`. `ryanccn/attic-action` handles install, login, substituter config, and pushing every store path the job produced at job end.
 
 ```yaml
@@ -76,7 +83,7 @@ jobs:
 
 Rules:
 
-- Set the `push.branches` filter to the repo's actual default branch (kolu uses `master`; many repos use `main`).
+- For **default branch only**, set the `push.branches` filter to the repo's actual default branch (kolu uses `master`; many repos use `main`). For **all branches**, drop the `branches:` filter so `push:` fires everywhere.
 - Drop `macos-latest` from the matrix if the repo has no Darwin consumers — building on macOS runners is slower and often unnecessary.
 - Keep both actions **pinned by commit SHA** (CodeQL flags unpinned third-party actions). The `# v35` / `# v0.5.0` trailing comments record the tag. Prefer the SHAs above unless a newer release is needed; do not replace them with floating tags.
 

--- a/skills/nix-oss-cache/SKILL.md
+++ b/skills/nix-oss-cache/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: nix-oss-cache
+description: Use this when setting up a GitHub repo to push its Nix builds to Juspay's shared OSS Attic cache (cache.nixos.asia/oss) — adds the substituter to flake.nix, a nix-cache.yml GitHub Actions workflow, and prompts for the ATTIC_TOKEN secret.
+---
+
+# Push to Juspay's OSS Nix cache
+
+Wire a GitHub repo into the shared Attic cache at [`cache.nixos.asia/oss`](https://cache.nixos.asia). CI builds the flake's default package on every push to the default branch and pushes the resulting closure, warming both CI and local `nix build`s for everyone. Reference: [juspay/kolu#1731](https://github.com/juspay/kolu/pull/1731), [#1733](https://github.com/juspay/kolu/pull/1733).
+
+Three pieces are needed: the cache as a **substituter** (so the repo _pulls_ from it), a **workflow** (so CI _pushes_ to it), and the **`ATTIC_TOKEN` secret** (so the push authenticates). Do all three.
+
+## 1. Add the cache as a substituter
+
+In the repo's top-level `flake.nix`, add (or extend) `nixConfig`:
+
+```nix
+nixConfig = {
+  extra-substituters = "https://cache.nixos.asia/oss";
+  extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+};
+```
+
+## 2. Add the workflow
+
+Create `.github/workflows/nix-cache.yml`. `ryanccn/attic-action` handles install, login, substituter config, and pushing every store path the job produced at job end.
+
+```yaml
+# Build the default package on linux + darwin and push each closure to the
+# shared Attic cache (https://cache.nixos.asia/oss).
+name: nix-cache
+
+on:
+  push:
+    branches: [master]   # set to the repo's default branch
+  pull_request:
+  workflow_dispatch:
+
+# Least privilege — this job only needs the checkout and ATTIC_TOKEN secret.
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin.
+        # Drop macos-latest if the repo is Linux-only.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
+      # v35 defaults to Nix 2.34.7, new enough for attic-action's `nix profile add`.
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+        with:
+          nix_conf: |
+            extra-substituters = https://cache.nixos.asia/oss
+            extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+            accept-flake-config = true
+
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
+
+      - name: Build
+        run: nix build -L --print-out-paths
+```
+
+Rules:
+
+- Set the `push.branches` filter to the repo's actual default branch (kolu uses `master`; many repos use `main`).
+- Drop `macos-latest` from the matrix if the repo has no Darwin consumers — building on macOS runners is slower and often unnecessary.
+- Keep both actions **pinned by commit SHA** (CodeQL flags unpinned third-party actions). The `# v35` / `# v0.5.0` trailing comments record the tag. Prefer the SHAs above unless a newer release is needed; do not replace them with floating tags.
+
+## 3. Set the ATTIC_TOKEN secret
+
+The token is a **push token** issued by the cache admin (Juspay infra) via `atticadm make-token`. Ask the maintainer/admin for one scoped to push the `oss` cache if you don't have it.
+
+Once the user has the token, **prompt them to run** (never paste the token into the repo or a command line that gets logged):
+
+```bash
+gh secret set ATTIC_TOKEN --repo <owner>/<repo>
+```
+
+`gh` prompts for the value interactively so it stays out of shell history. Confirm with `gh secret list --repo <owner>/<repo>` — the workflow fails loudly without this secret; there is no silent skip.
+
+## Verify
+
+Push to the default branch (or trigger via **Actions → nix-cache → Run workflow**). A green run means the closure was pushed. To confirm the pull side works, on another machine run `nix build` and check the log shows paths fetched from `cache.nixos.asia/oss`.


### PR DESCRIPTION
Adds a `nix-oss-cache` skill for wiring a GitHub repo into Juspay's shared OSS Attic cache at [`cache.nixos.asia/oss`](https://cache.nixos.asia).

The skill directs the agent through three pieces:

1. **Substituter** — add the cache to `flake.nix`'s `nixConfig` so the repo pulls from it.
2. **Workflow** — `.github/workflows/nix-cache.yml` that builds the flake's default package on linux + darwin and pushes each closure via `ryanccn/attic-action` (SHA-pinned, least-privilege permissions, default-branch + PR + manual triggers).
3. **Secret** — prompts the user to run `gh secret set ATTIC_TOKEN` interactively (keeping the token out of shell history) after obtaining a push token from the cache admin.

Reference: [juspay/kolu#1731](https://github.com/juspay/kolu/pull/1731), [#1733](https://github.com/juspay/kolu/pull/1733).

Also added to the README skills table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)